### PR TITLE
git-reintegrate: make main the default base branch

### DIFF
--- a/git-addons/git-reintegrate
+++ b/git-addons/git-reintegrate
@@ -161,7 +161,7 @@ class Branch
       system(*%w[git rev-parse --quiet --verify], "#{base}^{commit}", :out => File::NULL)
       die "no such commit: #{base}" unless $?.success?
     else
-      base = 'master'
+      base = 'main'
     end
 
     @int = @ref.gsub(%r{^refs/heads/}, 'refs/int/')
@@ -186,7 +186,7 @@ class Branch
       system(*%w[git rev-parse --quiet --verify], "#{base}^{commit}", :out => File::NULL)
       die "no such commit: #{base}" unless $?.success?
     else
-      base = 'master'
+      base = 'main'
     end
 
     @int = @ref.gsub(%r{^refs/heads/}, 'refs/int/')
@@ -573,7 +573,7 @@ def status_merge(branch_to_merge = nil)
     $stderr.puts "no branch specified with 'merge' command"
     return
   end
-  $status_base ||= 'master'
+  $status_base ||= 'main'
 
   if ! system(*%w[git rev-parse --verify --quiet], "#{branch_to_merge}^{commit}", :out => File::NULL)
     state = "."


### PR DESCRIPTION
With the default branch name change to main, git-reintegrate now results in an error when a base branch is not specified as the second argument to the create command.

```
:: git-reintegrate -c integrate
fatal: master: not a valid SHA1
error: pathspec 'integrate' did not match any file(s) known to git
Integration branch integrate created.
```