### PR TITLE
gitconfig: avoid multi-line strings for Xcode.

### DIFF
--- a/gitconfig/gitconfig
+++ b/gitconfig/gitconfig
@@ -145,9 +145,7 @@
 	# separate line than the function name.  This will match anything
 	# that looks like a function in column 1.  It seems like a good
 	# trade-off though.
-	xfuncname = "!^[ \t]*[A-Za-z_][A-Za-z_0-9]*:.*$\n"\
-"^(([A-Za-z_][A-Za-z_0-9]*([ \t*]+)?[A-Za-z_][A-Za-z_0-9]*([ \t]*::[ \t]*[^[:space:]]+)?){1,}[ \t]*\\([^;]*)$\n"\
-"^((typedef|struct|class|enum)[^;]*)$"
+	xfuncname = "!^[ \t]*[A-Za-z_][A-Za-z_0-9]*:.*$\n^(([A-Za-z_][A-Za-z_0-9]*([ \t*]+)?[A-Za-z_][A-Za-z_0-9]*([ \t]*::[ \t]*[^[:space:]]+)?){1,}[ \t]*\\([^;]*)$\n^((typedef|struct|class|enum)[^;]*)$"
 
 [fetch]
 	# Often helpful, but can be an issue for very active repositories.


### PR DESCRIPTION
It seems that Xcode does not like multi-line strings in gitconfig files. When creating a new project in Xcode with a git repository, Xcode errors with "An unknown error occurred...failed to parse config file: invalid configuration key (etc/gitconfig/gitconfig:150) (-1)".